### PR TITLE
Move gulp-util from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
     "gulp-mocha": "^2.2.0",
     "gulp-rename": "^1.2.0",
     "gulp-sequence": "^0.4.4",
-    "gulp-util": "^3.0.0",
     "mocha": "^2.1.0",
     "should": "^8.2.1"
   },
   "dependencies": {
+    "gulp-util": "^3.0.0",
     "lodash.defaults": "^4.0.1",
     "lodash.template": "^4.0.2",
     "vinyl": "^0.4.6"


### PR DESCRIPTION
@MrBoolean 

### What's broken

`command.js` requires `gulp-util`, but `gulp-util` is listed as a dev dep... which means it won't be installed for consumers of `gulp-run`

### Fix

Move `gulp-util` from devDependencies to dependencies.